### PR TITLE
docker build 前にフロントエンドをビルドしておく

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd backend/
 ./init.sh secret/h-develop2-firebase-adminsdk-hbh6m-c3e2782116.json
 ```
 
-## Frontend Deploy
+## Frontend Setup
 
 ``` bash
 cd frontend/


### PR DESCRIPTION
 手順のとおりに、`docker-compose build` を実行すると backendビルド時に `frontend/dist` が無いとエラーが出るため、事前にfrontend をビルドする手順を追加。