### PR TITLE
ラベルをEmailに修正。

### DIFF
--- a/frontend/src/components/pages/LoginPage.vue
+++ b/frontend/src/components/pages/LoginPage.vue
@@ -8,7 +8,7 @@
         <v-card-text>
           <v-text-field
             prepend-icon="mdi-account-circle"
-            label="ユーザ名"
+            label="Email"
             v-model="user.email"
             @keydown.enter="login"
           />


### PR DESCRIPTION
ラベルがユーザ名だと混乱しそうだったので、Emailに修正しました。